### PR TITLE
New Generic Field Rewriter

### DIFF
--- a/src/RewriteHandler.ts
+++ b/src/RewriteHandler.ts
@@ -39,7 +39,7 @@ export default class RewriteHandler {
         const isMatch = rewriter.matches(nodeAndVars, parents);
         if (isMatch) {
           rewrittenVariables = rewriter.rewriteVariables(rewrittenNodeAndVars, rewrittenVariables);
-          rewrittenNodeAndVars = rewriter.rewriteQuery(rewrittenNodeAndVars);
+          rewrittenNodeAndVars = rewriter.rewriteQuery(rewrittenNodeAndVars, rewrittenVariables);
           const simplePath = extractPath([...parents, rewrittenNodeAndVars.node]);
           let paths: ReadonlyArray<ReadonlyArray<string>> = [simplePath];
           const fragmentDef = parents.find(({ kind }) => kind === 'FragmentDefinition') as

--- a/src/rewriters/FieldArgTypeRewriter.ts
+++ b/src/rewriters/FieldArgTypeRewriter.ts
@@ -1,4 +1,12 @@
-import { ArgumentNode, ASTNode, FieldNode, parseType, TypeNode, VariableNode } from 'graphql';
+import {
+  ArgumentNode,
+  ValueNode,
+  ASTNode,
+  FieldNode,
+  parseType,
+  TypeNode,
+  VariableNode
+} from 'graphql';
 import { NodeAndVarDefs, nodesMatch } from '../ast';
 import { identifyFunc } from '../utils';
 import Rewriter, { RewriterOpts, Variables } from './Rewriter';
@@ -7,7 +15,17 @@ interface FieldArgTypeRewriterOpts extends RewriterOpts {
   argName: string;
   oldType: string;
   newType: string;
-  coerceVariable?: (variable: any) => any;
+  coerceVariable?: (variable: any, context: { variables: Variables; args: ArgumentNode[] }) => any;
+  /**
+   * EXPERIMENTAL:
+   *  This allows to coerce value of argument when their value is not stored in a variable
+   *  but comes in the query node itself.
+   *  NOTE: At the moment, the user has to return the ast value node herself.
+   */
+  coerceArgumentValue?: (
+    variable: any,
+    context: { variables: Variables; args: ArgumentNode[] }
+  ) => any;
 }
 
 /**
@@ -18,7 +36,13 @@ class FieldArgTypeRewriter extends Rewriter {
   protected argName: string;
   protected oldTypeNode: TypeNode;
   protected newTypeNode: TypeNode;
-  protected coerceVariable: (variable: any) => any;
+  // Passes context with rest of arguments and variables.
+  // Quite useful for variable coercion that depends on other arguments/variables
+  // (e.g., [offset, limit] to [pageSize, pageNumber] coercion)
+  protected coerceVariable;
+  // (Experimental): Used to coerce arguments whose value
+  // does not come in a variable.
+  protected coerceArgumentValue;
 
   constructor(options: FieldArgTypeRewriterOpts) {
     super(options);
@@ -26,6 +50,7 @@ class FieldArgTypeRewriter extends Rewriter {
     this.oldTypeNode = parseType(options.oldType);
     this.newTypeNode = parseType(options.newType);
     this.coerceVariable = options.coerceVariable || identifyFunc;
+    this.coerceArgumentValue = options.coerceArgumentValue || identifyFunc;
   }
 
   public matches(nodeAndVars: NodeAndVarDefs, parents: ASTNode[]) {
@@ -34,34 +59,81 @@ class FieldArgTypeRewriter extends Rewriter {
     const { variableDefinitions } = nodeAndVars;
     // is this a field with the correct fieldName and arguments?
     if (node.kind !== 'Field') return false;
-    if (node.name.value !== this.fieldName || !node.arguments) return false;
+
+    // If the fieldName doesnt match, but there are matchConditions.
+    // matchConditions should have higher priority than fieldName to determine a match.
+    if ((node.name.value !== this.fieldName && !this.matchConditions) || !node.arguments)
+      return false;
     // is there an argument with the correct name and type in a variable?
     const matchingArgument = node.arguments.find(arg => arg.name.value === this.argName);
-    if (!matchingArgument || matchingArgument.value.kind !== 'Variable') return false;
-    const varRef = matchingArgument.value.name.value;
 
-    // does the referenced variable have the correct type?
-    for (const varDefinition of variableDefinitions) {
-      if (varDefinition.variable.name.value === varRef) {
-        return nodesMatch(this.oldTypeNode, varDefinition.type);
+    if (!matchingArgument) return false;
+
+    // argument value is stored in a variable
+    if (matchingArgument.value.kind === 'Variable') {
+      const varRef = matchingArgument.value.name.value;
+      // does the referenced variable have the correct type?
+      for (const varDefinition of variableDefinitions) {
+        if (varDefinition.variable.name.value === varRef) {
+          return nodesMatch(this.oldTypeNode, varDefinition.type);
+        }
       }
     }
+    // argument value comes in query doc.
+    else {
+      const argRef = matchingArgument.value;
+      return nodesMatch(this.oldTypeNode, parseType(argRef.kind));
+    }
+
     return false;
   }
 
-  public rewriteQuery({ node, variableDefinitions }: NodeAndVarDefs) {
-    const varRefName = this.extractMatchingVarRefName(node as FieldNode);
-    const newVarDefs = variableDefinitions.map(varDef => {
-      if (varDef.variable.name.value !== varRefName) return varDef;
-      return { ...varDef, type: this.newTypeNode };
-    });
-    return { node, variableDefinitions: newVarDefs };
+  public rewriteQuery(
+    { node: astNode, variableDefinitions }: NodeAndVarDefs,
+    variables: Variables
+  ) {
+    const node = astNode as FieldNode;
+    const varRefName = this.extractMatchingVarRefName(node);
+    // If argument value is stored in a variable
+    if (varRefName) {
+      const newVarDefs = variableDefinitions.map(varDef => {
+        if (varDef.variable.name.value !== varRefName) return varDef;
+        return { ...varDef, type: this.newTypeNode };
+      });
+      return { node, variableDefinitions: newVarDefs };
+    }
+    // If argument value is not stored in a variable but in the query node.
+    else {
+      const matchingArgument = (node.arguments || []).find(arg => arg.name.value === this.argName);
+      if (node.arguments && matchingArgument) {
+        const args = [...node.arguments];
+        const newValue = this.coerceArgumentValue(matchingArgument.value, { variables, args });
+        /**
+          TODO: If somewhow we can get the schema here, we could make the coerceArgumentValue
+          even easier, as we would be able to construct the ast node for the argument value.
+          as of now, the user has to take care of correctly constructing the argument value ast node herself.
+
+          const schema = makeExecutableSchema({typeDefs})
+          const myCustomType = schema.getType("MY_CUSTOM_TYPE_NAME")
+          const newArgValue = astFromValue(newValue, myCustomType)
+          Object.assign(matchingArgument, { value: newArgValue })
+
+         */
+        Object.assign(matchingArgument, { value: newValue });
+      }
+      return { node, variableDefinitions };
+    }
   }
 
-  public rewriteVariables({ node }: NodeAndVarDefs, variables: Variables) {
+  public rewriteVariables({ node: astNode }: NodeAndVarDefs, variables: Variables) {
+    const node = astNode as FieldNode;
     if (!variables) return variables;
-    const varRefName = this.extractMatchingVarRefName(node as FieldNode);
-    return { ...variables, [varRefName]: this.coerceVariable(variables[varRefName]) };
+    const varRefName = this.extractMatchingVarRefName(node);
+    const args = [...(node.arguments ? node.arguments : [])];
+    return {
+      ...variables,
+      [varRefName]: this.coerceVariable(variables[varRefName], { variables, args })
+    };
   }
 
   private extractMatchingVarRefName(node: FieldNode) {

--- a/src/rewriters/FieldRewriter.ts
+++ b/src/rewriters/FieldRewriter.ts
@@ -1,0 +1,84 @@
+import { ASTNode, FieldNode, SelectionSetNode } from 'graphql';
+import { NodeAndVarDefs } from '../ast';
+import Rewriter, { RewriterOpts } from './Rewriter';
+
+interface FieldRewriterOpts extends RewriterOpts {
+  newFieldName?: string;
+  objectFieldName?: string;
+}
+
+/**
+ * More generic version of ScalarFieldToObjectField rewriter
+ */
+class FieldRewriter extends Rewriter {
+  protected newFieldName?: string;
+  protected objectFieldName?: string;
+
+  constructor(options: FieldRewriterOpts) {
+    super(options);
+    this.newFieldName = options.newFieldName;
+    this.objectFieldName = options.objectFieldName;
+  }
+
+  public matches(nodeAndVars: NodeAndVarDefs, parents: ASTNode[]): boolean {
+    if (!super.matches(nodeAndVars, parents)) return false;
+    const node = nodeAndVars.node as FieldNode;
+    // if there's the intention of converting the field to a subselection
+    // make sure there's no subselections on this field
+    if (node.selectionSet && !!this.objectFieldName) return false;
+    return true;
+  }
+
+  public rewriteQuery(nodeAndVarDefs: NodeAndVarDefs) {
+    const node = nodeAndVarDefs.node as FieldNode;
+    const { variableDefinitions } = nodeAndVarDefs;
+    // if there's the intention of converting the field to a subselection
+    // and there's a subselection already, just return
+    if (node.selectionSet && !!this.objectFieldName) return nodeAndVarDefs;
+
+    // if fieldName is meant to be renamed.
+    if (this.newFieldName) {
+      Object.assign(node.name, { value: this.newFieldName });
+    }
+
+    // if there's the intention of converting the field to a subselection
+    // of objectFieldNames
+    if (this.objectFieldName) {
+      const selectionSet: SelectionSetNode = {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: { kind: 'Name', value: this.objectFieldName }
+          }
+        ]
+      };
+      Object.assign(node, { selectionSet });
+    }
+
+    return {
+      variableDefinitions,
+      node
+    } as NodeAndVarDefs;
+  }
+
+  public rewriteResponse(response: any, key: string, index?: number) {
+    // Extract the element we are working on
+    const element = super.extractReponseElement(response, key, index);
+    if (element === null) return response;
+
+    let originalKey = key;
+    if (key === this.newFieldName) {
+      delete response[key];
+      if (this.fieldName) originalKey = this.fieldName;
+    }
+    // Undo the nesting in the response so it matches the original query
+    let newElement = element;
+    if (this.objectFieldName) {
+      newElement = element[this.objectFieldName];
+    }
+    return super.rewriteResponseElement(response, newElement, originalKey, index);
+  }
+}
+
+export default FieldRewriter;

--- a/src/rewriters/Rewriter.ts
+++ b/src/rewriters/Rewriter.ts
@@ -28,7 +28,8 @@ abstract class Rewriter {
 
   public matches(nodeAndVarDefs: NodeAndVarDefs, parents: ReadonlyArray<ASTNode>): boolean {
     const { node } = nodeAndVarDefs;
-    if (node.kind !== 'Field' || node.name.value !== this.fieldName) return false;
+    if (node.kind !== 'Field' || (node.name.value !== this.fieldName && !this.matchConditions))
+      return false;
     const root = parents[0];
     if (
       root.kind === 'OperationDefinition' &&
@@ -48,11 +49,11 @@ abstract class Rewriter {
     return true;
   }
 
-  public rewriteQuery(nodeAndVarDefs: NodeAndVarDefs): NodeAndVarDefs {
+  public rewriteQuery(nodeAndVarDefs: NodeAndVarDefs, _?: Variables): NodeAndVarDefs {
     return nodeAndVarDefs;
   }
 
-  public rewriteVariables(nodeAndVarDefs: NodeAndVarDefs, variables: Variables): Variables {
+  public rewriteVariables(_: NodeAndVarDefs, variables: Variables): Variables {
     return variables;
   }
 

--- a/src/rewriters/Rewriter.ts
+++ b/src/rewriters/Rewriter.ts
@@ -40,8 +40,9 @@ abstract class Rewriter {
     if (
       node.kind !== 'Field' ||
       (this.fieldName ? node.name.value !== this.fieldName : !this.matchConditions)
-    )
+    ) {
       return false;
+    }
     const root = parents[0];
     if (
       root.kind === 'OperationDefinition' &&
@@ -61,11 +62,11 @@ abstract class Rewriter {
     return true;
   }
 
-  public rewriteQuery(nodeAndVarDefs: NodeAndVarDefs, _?: Variables): NodeAndVarDefs {
+  public rewriteQuery(nodeAndVarDefs: NodeAndVarDefs, variables: Variables): NodeAndVarDefs {
     return nodeAndVarDefs;
   }
 
-  public rewriteVariables(_: NodeAndVarDefs, variables: Variables): Variables {
+  public rewriteVariables(nodeAndVarDefs: NodeAndVarDefs, variables: Variables): Variables {
     return variables;
   }
 

--- a/src/rewriters/Rewriter.ts
+++ b/src/rewriters/Rewriter.ts
@@ -6,7 +6,7 @@ export type Variables = { [key: string]: any } | undefined;
 export type RootType = 'query' | 'mutation' | 'fragment';
 
 export interface RewriterOpts {
-  fieldName: string;
+  fieldName?: string;
   rootTypes?: RootType[];
   matchConditions?: matchCondition[];
 }
@@ -16,19 +16,31 @@ export interface RewriterOpts {
  * Extend this class and overwrite its methods to create a new rewriter
  */
 abstract class Rewriter {
-  protected fieldName: string;
   protected rootTypes: RootType[] = ['query', 'mutation', 'fragment'];
+  protected fieldName?: string;
   protected matchConditions?: matchCondition[];
 
   constructor({ fieldName, rootTypes, matchConditions }: RewriterOpts) {
     this.fieldName = fieldName;
     this.matchConditions = matchConditions;
+    if (!this.fieldName && !this.matchConditions) {
+      throw new Error(
+        'Neither a fieldName or matchConditions were provided. Please choose to pass either one in order to be able to detect which fields to rewrite.'
+      );
+    }
     if (rootTypes) this.rootTypes = rootTypes;
   }
 
   public matches(nodeAndVarDefs: NodeAndVarDefs, parents: ReadonlyArray<ASTNode>): boolean {
     const { node } = nodeAndVarDefs;
-    if (node.kind !== 'Field' || (node.name.value !== this.fieldName && !this.matchConditions))
+
+    // If no fieldName is provided, check for defined matchConditions.
+    // This avoids having to define one rewriter for many fields individually.
+    // Alternatively, regex matching for fieldName could be implemented.
+    if (
+      node.kind !== 'Field' ||
+      (this.fieldName ? node.name.value !== this.fieldName : !this.matchConditions)
+    )
       return false;
     const root = parents[0];
     if (

--- a/test/functional/rewriteField.test.ts
+++ b/test/functional/rewriteField.test.ts
@@ -1,0 +1,451 @@
+import RewriteHandler from '../../src/RewriteHandler';
+import FieldRewriter from '../../src/rewriters/FieldRewriter';
+import { gqlFmt } from '../testUtils';
+
+describe('Rewrite scalar field to be a nested object with a single scalar field', () => {
+  it('rewrites a scalar field to be an object field with 1 scalar subfield', () => {
+    const handler = new RewriteHandler([
+      new FieldRewriter({
+        fieldName: 'title',
+        objectFieldName: 'text'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            title
+            color
+          }
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            title {
+              text
+            }
+            color
+          }
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          thingField: {
+            id: 1,
+            title: {
+              text: 'THING'
+            },
+            color: 'blue'
+          }
+        }
+      })
+    ).toEqual({
+      theThing: {
+        thingField: {
+          id: 1,
+          title: 'THING',
+          color: 'blue'
+        }
+      }
+    });
+  });
+
+  it('rewrites a scalar field to be a renamed object field with 1 scalar subfield', () => {
+    const handler = new RewriteHandler([
+      new FieldRewriter({
+        fieldName: 'subField',
+        newFieldName: 'renamedSubField',
+        objectFieldName: 'value'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            subField
+            color
+          }
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            renamedSubField {
+              value
+            }
+            color
+          }
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          thingField: {
+            id: 1,
+            renamedSubField: {
+              value: 'THING'
+            },
+            color: 'blue'
+          }
+        }
+      })
+    ).toEqual({
+      theThing: {
+        thingField: {
+          id: 1,
+          subField: 'THING',
+          color: 'blue'
+        }
+      }
+    });
+  });
+
+  it('renames a field', () => {
+    const handler = new RewriteHandler([
+      new FieldRewriter({
+        fieldName: 'subField',
+        newFieldName: 'renamedSubField'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            subField {
+              value
+            }
+            color
+          }
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            renamedSubField {
+              value
+            }
+            color
+          }
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          thingField: {
+            id: 1,
+            renamedSubField: {
+              value: 'THING'
+            },
+            color: 'blue'
+          }
+        }
+      })
+    ).toEqual({
+      theThing: {
+        thingField: {
+          id: 1,
+          subField: { value: 'THING' },
+          color: 'blue'
+        }
+      }
+    });
+  });
+
+  it('rewrites a scalar field to be a renamed object field with 1 scalar subfield', () => {
+    const handler = new RewriteHandler([
+      new FieldRewriter({
+        fieldName: 'subField',
+        newFieldName: 'renamedSubField',
+        objectFieldName: 'value'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            subField
+            color
+          }
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            renamedSubField {
+              value
+            }
+            color
+          }
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          thingField: {
+            id: 1,
+            renamedSubField: {
+              value: 'THING'
+            },
+            color: 'blue'
+          }
+        }
+      })
+    ).toEqual({
+      theThing: {
+        thingField: {
+          id: 1,
+          subField: 'THING',
+          color: 'blue'
+        }
+      }
+    });
+  });
+
+  it('works with fragments', () => {
+    const handler = new RewriteHandler([
+      new FieldRewriter({
+        fieldName: 'title',
+        objectFieldName: 'text'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        title
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        title {
+          text
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          id: 1,
+          title: {
+            text: 'THING'
+          }
+        }
+      })
+    ).toEqual({
+      theThing: {
+        id: 1,
+        title: 'THING'
+      }
+    });
+  });
+
+  it('works within repeated and nested fragments', () => {
+    const handler = new RewriteHandler([
+      new FieldRewriter({
+        fieldName: 'title',
+        objectFieldName: 'text'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+        otherThing {
+          ...otherThingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        title
+      }
+
+      fragment otherThingFragment on Thing {
+        id
+        edges {
+          node {
+            ...thingFragment
+          }
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+        otherThing {
+          ...otherThingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        title {
+          text
+        }
+      }
+
+      fragment otherThingFragment on Thing {
+        id
+        edges {
+          node {
+            ...thingFragment
+          }
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          id: 1,
+          title: {
+            text: 'THING'
+          }
+        },
+        otherThing: {
+          id: 3,
+          edges: [
+            {
+              node: {
+                title: {
+                  text: 'NODE_TEXT1'
+                }
+              }
+            },
+            {
+              node: {
+                title: {
+                  text: 'NODE_TEXT2'
+                }
+              }
+            }
+          ]
+        }
+      })
+    ).toEqual({
+      theThing: {
+        id: 1,
+        title: 'THING'
+      },
+      otherThing: {
+        id: 3,
+        edges: [
+          {
+            node: {
+              title: 'NODE_TEXT1'
+            }
+          },
+          {
+            node: {
+              title: 'NODE_TEXT2'
+            }
+          }
+        ]
+      }
+    });
+  });
+
+  it('rewrites a scalar field array to be an array of object fields with 1 scalar subfield', () => {
+    const handler = new RewriteHandler([
+      new FieldRewriter({
+        fieldName: 'titles',
+        objectFieldName: 'text'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getThing {
+        thing {
+          titles
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getThing {
+        thing {
+          titles {
+            text
+          }
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        thing: {
+          titles: [
+            {
+              text: 'THING'
+            }
+          ]
+        }
+      })
+    ).toEqual({
+      thing: {
+        titles: ['THING']
+      }
+    });
+  });
+});

--- a/test/functional/rewriteFieldArgType.test.ts
+++ b/test/functional/rewriteFieldArgType.test.ts
@@ -186,7 +186,6 @@ describe('Rewrite field arg type', () => {
         newType: 'Int!'
       });
     } catch (error) {
-      console.log(error.message);
       expect(
         error.message.includes('Neither a fieldName or matchConditions were provided')
       ).toEqual(true);

--- a/test/functional/rewriteFieldArgType.test.ts
+++ b/test/functional/rewriteFieldArgType.test.ts
@@ -1,3 +1,4 @@
+import { FieldNode, astFromValue, GraphQLInt, Kind } from 'graphql';
 import RewriteHandler from '../../src/RewriteHandler';
 import FieldArgTypeRewriter from '../../src/rewriters/FieldArgTypeRewriter';
 import { gqlFmt } from '../testUtils';
@@ -86,6 +87,145 @@ describe('Rewrite field arg type', () => {
         argName: 'identifier',
         oldType: 'String!',
         newType: 'Int!',
+        coerceVariable: val => parseInt(val, 10)
+      })
+    ]);
+    expect(handler.rewriteRequest(query, { arg1: '123', arg2: 'blah' })).toEqual({
+      query: expectedRewritenQuery,
+      variables: {
+        arg1: 123,
+        arg2: 'blah'
+      }
+    });
+  });
+
+  it('variable coercion comes with additional variables and arguments as context.', () => {
+    const query = gqlFmt`
+      query doTheThings($arg1: String!, $arg2: String) {
+        things(identifier: $arg1, arg2: $arg2, arg3: "blah") {
+          cat
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query doTheThings($arg1: Int!, $arg2: String) {
+        things(identifier: $arg1, arg2: $arg2, arg3: "blah") {
+          cat
+        }
+      }
+    `;
+
+    const handler = new RewriteHandler([
+      new FieldArgTypeRewriter({
+        fieldName: 'things',
+        argName: 'identifier',
+        oldType: 'String!',
+        newType: 'Int!',
+        coerceVariable: (_, { variables = {}, args }) => {
+          expect(args.length).toBe(3);
+          expect(args[0].kind).toBe('Argument');
+          expect(args[0].value.kind).toBe(Kind.VARIABLE);
+          expect(args[1].kind).toBe('Argument');
+          expect(args[1].value.kind).toBe(Kind.VARIABLE);
+          expect(args[2].kind).toBe('Argument');
+          expect(args[2].value.kind).toBe(Kind.STRING);
+          const { arg2 = 0 } = variables;
+          return parseInt(arg2, 10);
+        }
+      })
+    ]);
+    expect(handler.rewriteRequest(query, { arg1: 'someString', arg2: '123' })).toEqual({
+      query: expectedRewritenQuery,
+      variables: {
+        arg1: 123,
+        arg2: '123'
+      }
+    });
+  });
+
+  it('can be passed a coerceArgumentValue function to change argument values.', () => {
+    const query = gqlFmt`
+      query doTheThings {
+        things(identifier: "123", arg2: "blah") {
+          cat
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query doTheThings {
+        things(identifier: 123, arg2: "blah") {
+          cat
+        }
+      }
+    `;
+
+    const handler = new RewriteHandler([
+      new FieldArgTypeRewriter({
+        fieldName: 'things',
+        argName: 'identifier',
+        oldType: 'String!',
+        newType: 'Int!',
+        coerceArgumentValue: argValue => {
+          const value = argValue.value;
+          const newArgValue = astFromValue(parseInt(value, 10), GraphQLInt);
+          return newArgValue;
+        }
+      })
+    ]);
+
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+  });
+
+  it('should fail if neither a fieldName or matchConditions are provided', () => {
+    try {
+      new FieldArgTypeRewriter({
+        argName: 'identifier',
+        oldType: 'String!',
+        newType: 'Int!'
+      });
+    } catch (error) {
+      console.log(error.message);
+      expect(
+        error.message.includes('Neither a fieldName or matchConditions were provided')
+      ).toEqual(true);
+    }
+  });
+
+  it('allows matching using matchConditions when fieldName is not provided.', () => {
+    const query = gqlFmt`
+      query doTheThings($arg1: String!, $arg2: String) {
+        things(identifier: $arg1, arg2: $arg2) {
+          cat
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query doTheThings($arg1: Int!, $arg2: String) {
+        things(identifier: $arg1, arg2: $arg2) {
+          cat
+        }
+      }
+    `;
+
+    // Tests a dummy regex to match the "things" field.
+    const fieldNameRegExp = '.hings';
+
+    const handler = new RewriteHandler([
+      new FieldArgTypeRewriter({
+        argName: 'identifier',
+        oldType: 'String!',
+        newType: 'Int!',
+        matchConditions: [
+          nodeAndVars => {
+            const node = nodeAndVars.node as FieldNode;
+            const {
+              name: { value: fieldName }
+            } = node;
+            return fieldName.search(new RegExp(fieldNameRegExp)) !== -1;
+          }
+        ],
         coerceVariable: val => parseInt(val, 10)
       })
     ]);


### PR DESCRIPTION
@chanind Ive added a new Rewriter: `FieldRewriter` inspired by the `ScalarFieldToObjectFieldRewriter` but with the ability to support both "scalar to object field rewrite" with/or field rename rewrite.

PR should be backwards compatible and comes with unit tests.